### PR TITLE
Remove ErrCh from server struct

### DIFF
--- a/hw12_13_14_15_16_calendar/internal/server/http/server.go
+++ b/hw12_13_14_15_16_calendar/internal/server/http/server.go
@@ -10,11 +10,10 @@ import (
 	"github.com/EvGesh4And/golang-homework/hw12_13_14_15_16_calendar/internal/server"
 )
 
-type Server struct { // TODO
+type Server struct {
 	logger     *slog.Logger
 	app        server.Application
 	httpServer *http.Server
-	ErrCh      chan error
 	handler    http.Handler
 }
 
@@ -41,8 +40,6 @@ func NewServerHTTP(host string, port int, logger *slog.Logger, app server.Applic
 	}
 	s.httpServer = httpServer
 	s.handler = wrapped
-
-	s.ErrCh = make(chan error, 1)
 	return s
 }
 


### PR DESCRIPTION
## Summary
- tidy up the HTTP server struct
- drop unused `ErrCh` channel

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `go vet ./...` in `hw12_13_14_15_16_calendar` *(fails to download modules)*
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `go test ./...` in `hw12_13_14_15_16_calendar` *(fails to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685fabe037d08329b18cfbb1ccf79780