### PR TITLE
Add ack error handling for rabbit consumer

### DIFF
--- a/hw12_13_14_15_16_calendar/internal/rabbitmq/consumer/consumer.go
+++ b/hw12_13_14_15_16_calendar/internal/rabbitmq/consumer/consumer.go
@@ -208,7 +208,9 @@ outer:
 				}
 				c.logger.InfoContext(ctx, "notification unmarshalled", "notification", notification)
 
-				d.Ack(false)
+				if err := c.ackDelivery(ctx, d); err != nil {
+					return err
+				}
 
 				c.logger.InfoContext(ctx, "notification event", "notification", notification)
 			}
@@ -232,6 +234,14 @@ func (c *RabbitConsumer) Shutdown() error {
 	<-c.done
 
 	return errors.Join(errs...)
+}
+
+func (c *RabbitConsumer) ackDelivery(ctx context.Context, d amqp.Delivery) error {
+	if err := d.Ack(false); err != nil {
+		c.logger.ErrorContext(ctx, "failed to acknowledge message", slog.String("error", err.Error()))
+		return fmt.Errorf("RabbitConsumer.Handle: ack: %w", err)
+	}
+	return nil
 }
 
 func (c *RabbitConsumer) startReconnectLoop(ctx context.Context, cfg RabbitMQConf) {

--- a/hw12_13_14_15_16_calendar/internal/rabbitmq/consumer/consumer_test.go
+++ b/hw12_13_14_15_16_calendar/internal/rabbitmq/consumer/consumer_test.go
@@ -1,0 +1,33 @@
+package consumer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/EvGesh4And/golang-homework/hw12_13_14_15_16_calendar/internal/logger"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+type ackMock struct{ err error }
+
+func (a *ackMock) Ack(tag uint64, multiple bool) error                { return a.err }
+func (a *ackMock) Nack(tag uint64, multiple bool, requeue bool) error { return nil }
+func (a *ackMock) Reject(tag uint64, requeue bool) error              { return nil }
+
+func TestAckDeliveryError(t *testing.T) {
+	var buf bytes.Buffer
+	lg := logger.New("debug", &buf)
+	c := &RabbitConsumer{logger: lg}
+
+	d := amqp.Delivery{
+		Acknowledger: &ackMock{err: errors.New("ack error")},
+		DeliveryTag:  1,
+	}
+
+	err := c.ackDelivery(context.Background(), d)
+	require.Error(t, err)
+	require.Contains(t, buf.String(), "failed to acknowledge message")
+}


### PR DESCRIPTION
## Summary
- capture `Ack` errors in RabbitMQ consumer
- log and return ack errors
- add test for ack error path