### PR TITLE
Improve error wrapping

### DIFF
--- a/hw12_13_14_15_16_calendar/internal/logger/middleware.go
+++ b/hw12_13_14_15_16_calendar/internal/logger/middleware.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -107,6 +108,9 @@ func WrapError(ctx context.Context, err error) error {
 	c := logCtx{}
 	if x, ok := ctx.Value(key).(logCtx); ok {
 		c = x
+	}
+	if c.Method != "" {
+		err = fmt.Errorf("%s: %w", c.Method, err)
 	}
 	return &errorWithCtx{
 		next: err,

--- a/hw12_13_14_15_16_calendar/internal/storage/memory/storage.go
+++ b/hw12_13_14_15_16_calendar/internal/storage/memory/storage.go
@@ -33,17 +33,17 @@ func (s *Storage) CreateEvent(ctx context.Context, event storage.Event) error {
 	s.logger.DebugContext(ctx, "попытка создать событие")
 
 	if err := ctx.Err(); err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.CreateEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, ok := s.eventMap[event.ID]; ok {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.CreateEvent: %w", storage.ErrIDRepeated))
+		return logger.WrapError(ctx, storage.ErrIDRepeated)
 	}
 	if !s.intervals.AddIfFree(event.GetInterval()) {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.CreateEvent: %w", storage.ErrDateBusy))
+		return logger.WrapError(ctx, storage.ErrDateBusy)
 	}
 
 	s.eventMap[event.ID] = event
@@ -55,7 +55,7 @@ func (s *Storage) UpdateEvent(ctx context.Context, id uuid.UUID, newEvent storag
 	s.logger.DebugContext(ctx, "попытка обновить событие")
 
 	if err := ctx.Err(); err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.UpdateEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 
 	s.mu.Lock()
@@ -63,11 +63,11 @@ func (s *Storage) UpdateEvent(ctx context.Context, id uuid.UUID, newEvent storag
 
 	oldEvent, ok := s.eventMap[id]
 	if !ok {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.UpdateEvent: %w", storage.ErrIDNotExist))
+		return logger.WrapError(ctx, storage.ErrIDNotExist)
 	}
 
 	if !s.intervals.Replace(newEvent.GetInterval(), oldEvent.GetInterval()) {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.UpdateEvent: %w", storage.ErrDateBusy))
+		return logger.WrapError(ctx, storage.ErrDateBusy)
 	}
 
 	s.eventMap[id] = newEvent
@@ -79,7 +79,7 @@ func (s *Storage) DeleteEvent(ctx context.Context, id uuid.UUID) error {
 	s.logger.DebugContext(ctx, "попытка удалить событие")
 
 	if err := ctx.Err(); err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.DeleteEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 
 	s.mu.Lock()
@@ -87,7 +87,7 @@ func (s *Storage) DeleteEvent(ctx context.Context, id uuid.UUID) error {
 
 	event, ok := s.eventMap[id]
 	if !ok {
-		return logger.WrapError(ctx, fmt.Errorf("storage:memory.DeleteEvent: %w", storage.ErrIDNotExist))
+		return logger.WrapError(ctx, storage.ErrIDNotExist)
 	}
 
 	s.intervals.Remove(event.GetInterval())
@@ -126,7 +126,7 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 	s.logger.DebugContext(ctx, "попытка получить события за интервал")
 
 	if err := ctx.Err(); err != nil {
-		return nil, logger.WrapError(ctx, fmt.Errorf("storage:memory.getEvents: %w", err))
+		return nil, logger.WrapError(ctx, err)
 	}
 
 	s.mu.RLock()
@@ -139,7 +139,7 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 	for _, inter := range intervals {
 		event, ok := s.eventMap[inter.ID]
 		if !ok {
-			return nil, logger.WrapError(ctx, fmt.Errorf("storage:memory.getEvents: %w", storage.ErrGetEvents))
+			return nil, logger.WrapError(ctx, storage.ErrGetEvents)
 		}
 		res = append(res, event)
 	}

--- a/hw12_13_14_15_16_calendar/internal/storage/sql/storage.go
+++ b/hw12_13_14_15_16_calendar/internal/storage/sql/storage.go
@@ -99,7 +99,7 @@ func (s *Storage) CreateEvent(ctx context.Context, event storage.Event) error {
 		int64(event.TimeBefore.Seconds()),
 	)
 	if err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:sql.CreateEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 	s.logger.InfoContext(ctx, "успешно создано событие")
 	return nil
@@ -126,7 +126,7 @@ func (s *Storage) UpdateEvent(ctx context.Context, id uuid.UUID, newEvent storag
 		id,
 	)
 	if err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:sql.UpdateEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 	s.logger.InfoContext(ctx, "успешно обновлено событие")
 	return nil
@@ -144,7 +144,7 @@ func (s *Storage) DeleteEvent(ctx context.Context, id uuid.UUID) error {
 
 	_, err := s.db.ExecContext(ctx, query, id)
 	if err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:sql.DeleteEvent: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 	s.logger.InfoContext(ctx, "успешно удалено событие")
 	return nil
@@ -186,7 +186,7 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 
 	rows, err := s.db.QueryContext(ctx, query, start, start.Add(d))
 	if err != nil {
-		return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetEvents%s: %w", period, err))
+		return nil, logger.WrapError(ctx, err)
 	}
 	defer rows.Close()
 
@@ -203,12 +203,12 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 			&event.End,
 			&intervalStr,
 		); err != nil {
-			return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetEvents%s: %w", period, err))
+			return nil, logger.WrapError(ctx, err)
 		}
 
 		dur, err := parsePostgresInterval(intervalStr)
 		if err != nil {
-			return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetEvents%s: %w", period, err))
+			return nil, logger.WrapError(ctx, err)
 		}
 		event.TimeBefore = dur
 
@@ -216,7 +216,7 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetEvents%s: %w", period, err))
+		return nil, logger.WrapError(ctx, err)
 	}
 
 	s.logger.InfoContext(ctx, "успешно получены события", "count", len(events))
@@ -242,7 +242,7 @@ func (s *Storage) GetNotifications(
 
 	rows, err := s.db.QueryContext(ctx, query, currTime, currTime.Add(tick))
 	if err != nil {
-		return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetNotifications: %w", err))
+		return nil, logger.WrapError(ctx, err)
 	}
 	defer rows.Close()
 
@@ -255,14 +255,14 @@ func (s *Storage) GetNotifications(
 			&notification.Start,
 			&notification.UserID,
 		); err != nil {
-			return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetNotifications: %w", err))
+			return nil, logger.WrapError(ctx, err)
 		}
 
 		notifications = append(notifications, notification)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, logger.WrapError(ctx, fmt.Errorf("storage:sql.GetNotifications: %w", err))
+		return nil, logger.WrapError(ctx, err)
 	}
 
 	s.logger.InfoContext(ctx, "успешно получены уведомления", "count", len(notifications))
@@ -283,11 +283,11 @@ func (s *Storage) DeleteOldEvents(ctx context.Context, delTime time.Time) error 
 
 	res, err := s.db.ExecContext(ctx, query, delTime)
 	if err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:sql.DeleteOldEvents: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 	count, err := res.RowsAffected()
 	if err != nil {
-		return logger.WrapError(ctx, fmt.Errorf("storage:sql.DeleteOldEvents: %w", err))
+		return logger.WrapError(ctx, err)
 	}
 	if count > 0 {
 		s.logger.InfoContext(ctx, "успешно удалены старые события", "count", count)


### PR DESCRIPTION
## Summary
- prefix errors with context method in `logger.WrapError`
- simplify error wrapping in memory and SQL storage implementations