### PR TITLE
Uniform logging

### DIFF
--- a/hw12_13_14_15_16_calendar/internal/app/app.go
+++ b/hw12_13_14_15_16_calendar/internal/app/app.go
@@ -17,6 +17,11 @@ type App struct {
 	logger  *slog.Logger
 }
 
+func (a *App) setLogCompMeth(ctx context.Context, method string) context.Context {
+	ctx = logger.WithLogComponent(ctx, "app")
+	return logger.WithLogMethod(ctx, method)
+}
+
 // Storage defines persistence methods used by App.
 type Storage interface {
 	CreateEvent(context.Context, storage.Event) error
@@ -37,14 +42,14 @@ func New(logger *slog.Logger, storage Storage) *App {
 
 // CreateEvent validates and stores a new event.
 func (a *App) CreateEvent(ctx context.Context, event storage.Event) error {
-	ctx = logger.WithLogMethod(ctx, "CreateEvent")
+	ctx = a.setLogCompMeth(ctx, "CreateEvent")
 	a.logger.DebugContext(ctx, "attempting to create event")
 	if err := event.CheckValid(); err != nil {
-		return fmt.Errorf("app.CreateEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	err := a.storage.CreateEvent(ctx, event)
 	if err != nil {
-		return fmt.Errorf("app.CreateEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "event created successfully")
 	return nil
@@ -52,14 +57,14 @@ func (a *App) CreateEvent(ctx context.Context, event storage.Event) error {
 
 // UpdateEvent validates and updates an existing event.
 func (a *App) UpdateEvent(ctx context.Context, id uuid.UUID, event storage.Event) error {
-	ctx = logger.WithLogMethod(ctx, "UpdateEvent")
+	ctx = a.setLogCompMeth(ctx, "UpdateEvent")
 	a.logger.DebugContext(ctx, "attempting to update event")
 	if err := event.CheckValid(); err != nil {
-		return fmt.Errorf("app.UpdateEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	err := a.storage.UpdateEvent(ctx, id, event)
 	if err != nil {
-		return fmt.Errorf("app.UpdateEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "event updated successfully")
 	return nil
@@ -67,14 +72,14 @@ func (a *App) UpdateEvent(ctx context.Context, id uuid.UUID, event storage.Event
 
 // DeleteEvent removes an event by its ID.
 func (a *App) DeleteEvent(ctx context.Context, id uuid.UUID) error {
-	ctx = logger.WithLogMethod(ctx, "DeleteEvent")
+	ctx = a.setLogCompMeth(ctx, "DeleteEvent")
 	a.logger.DebugContext(ctx, "attempting to delete event")
 	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("storage:memory.CreateEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	err := a.storage.DeleteEvent(ctx, id)
 	if err != nil {
-		return fmt.Errorf("app.DeleteEvent: %w", err)
+		return logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "event deleted successfully")
 	return nil
@@ -82,12 +87,12 @@ func (a *App) DeleteEvent(ctx context.Context, id uuid.UUID) error {
 
 // GetEventsDay retrieves events for one day.
 func (a *App) GetEventsDay(ctx context.Context, start time.Time) ([]storage.Event, error) {
-	ctx = logger.WithLogMethod(ctx, "GetEventsDay")
+	ctx = a.setLogCompMeth(ctx, "GetEventsDay")
 	ctx = logger.WithLogStart(ctx, start)
 	a.logger.DebugContext(ctx, "attempting to get events for day")
 	events, err := a.storage.GetEventsDay(ctx, start)
 	if err != nil {
-		return nil, fmt.Errorf("app.GetEventsDay: %w", err)
+		return nil, logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "events retrieved successfully", "count", len(events))
 	return events, nil
@@ -95,12 +100,12 @@ func (a *App) GetEventsDay(ctx context.Context, start time.Time) ([]storage.Even
 
 // GetEventsWeek retrieves events for one week.
 func (a *App) GetEventsWeek(ctx context.Context, start time.Time) ([]storage.Event, error) {
-	ctx = logger.WithLogMethod(ctx, "GetEventsWeek")
+	ctx = a.setLogCompMeth(ctx, "GetEventsWeek")
 	ctx = logger.WithLogStart(ctx, start)
 	a.logger.DebugContext(ctx, "attempting to get events for week")
 	events, err := a.storage.GetEventsWeek(ctx, start)
 	if err != nil {
-		return nil, fmt.Errorf("app.GetEventsWeek: %w", err)
+		return nil, logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "events retrieved successfully", "count", len(events))
 	return events, nil
@@ -108,12 +113,12 @@ func (a *App) GetEventsWeek(ctx context.Context, start time.Time) ([]storage.Eve
 
 // GetEventsMonth retrieves events for one month.
 func (a *App) GetEventsMonth(ctx context.Context, start time.Time) ([]storage.Event, error) {
-	ctx = logger.WithLogMethod(ctx, "GetEventsMonth")
+	ctx = a.setLogCompMeth(ctx, "GetEventsMonth")
 	ctx = logger.WithLogStart(ctx, start)
 	a.logger.DebugContext(ctx, "attempting to get events for month")
 	events, err := a.storage.GetEventsMonth(ctx, start)
 	if err != nil {
-		return nil, fmt.Errorf("app.GetEventsMonth: %w", err)
+		return nil, logger.WrapError(ctx, err)
 	}
 	a.logger.InfoContext(ctx, "events retrieved successfully", "count", len(events))
 	return events, nil

--- a/hw12_13_14_15_16_calendar/internal/scheduler/scheduler.go
+++ b/hw12_13_14_15_16_calendar/internal/scheduler/scheduler.go
@@ -31,6 +31,11 @@ type Scheduler struct {
 	logger    *slog.Logger
 }
 
+func (s *Scheduler) setLogCompMeth(ctx context.Context, method string) context.Context {
+	ctx = logger.WithLogComponent(ctx, "scheduler")
+	return logger.WithLogMethod(ctx, method)
+}
+
 // NewScheduler creates a new Scheduler instance.
 func NewScheduler(logger *slog.Logger, storage Storage, publisher Publisher, cfg NotificationsConf) *Scheduler {
 	return &Scheduler{
@@ -44,7 +49,7 @@ func NewScheduler(logger *slog.Logger, storage Storage, publisher Publisher, cfg
 
 // Start runs the scheduler loop until the context is cancelled.
 func (s *Scheduler) Start(ctx context.Context) {
-	ctx = logger.WithLogMethod(ctx, "Start")
+	ctx = s.setLogCompMeth(ctx, "Start")
 
 	s.logger.InfoContext(ctx, "start scheduler")
 
@@ -69,7 +74,7 @@ func (s *Scheduler) Start(ctx context.Context) {
 
 // PublishNotifications sends notifications and removes old events.
 func (s *Scheduler) PublishNotifications(ctx context.Context) {
-	ctx = logger.WithLogMethod(ctx, "PublishNotifications")
+	ctx = s.setLogCompMeth(ctx, "PublishNotifications")
 
 	currTime := time.Now()
 	ctx = logger.WithLogStart(ctx, currTime)

--- a/hw12_13_14_15_16_calendar/internal/server/grpc/server.go
+++ b/hw12_13_14_15_16_calendar/internal/server/grpc/server.go
@@ -21,6 +21,11 @@ type CalendarServer struct {
 	lis net.Listener
 }
 
+func (s *CalendarServer) setLogCompMeth(ctx context.Context, method string) context.Context {
+	ctx = logger.WithLogComponent(ctx, "server.grpc")
+	return logger.WithLogMethod(ctx, method)
+}
+
 // NewServerGRPC creates a new gRPC calendar server.
 func NewServerGRPC(logger *slog.Logger, lis net.Listener, app server.Application) *CalendarServer {
 	return &CalendarServer{
@@ -32,7 +37,7 @@ func NewServerGRPC(logger *slog.Logger, lis net.Listener, app server.Application
 
 // CreateEvent handles creation of a new event via gRPC.
 func (s *CalendarServer) CreateEvent(ctx context.Context, req *pb.CreateEventReq) (*emptypb.Empty, error) {
-	ctx = logger.WithLogMethod(ctx, "CreateEvent")
+	ctx = s.setLogCompMeth(ctx, "CreateEvent")
 	event, err := getEventFromBody(ctx, s.logger, req)
 	if err != nil {
 		s.logger.ErrorContext(logger.ErrorCtx(ctx, err), err.Error())
@@ -53,7 +58,7 @@ func (s *CalendarServer) CreateEvent(ctx context.Context, req *pb.CreateEventReq
 
 // UpdateEvent handles event updates via gRPC.
 func (s *CalendarServer) UpdateEvent(ctx context.Context, req *pb.UpdateEventReq) (*emptypb.Empty, error) {
-	ctx = logger.WithLogMethod(ctx, "UpdateEvent")
+	ctx = s.setLogCompMeth(ctx, "UpdateEvent")
 	event, err := getEventFromBody(ctx, s.logger, req)
 	if err != nil {
 		s.logger.ErrorContext(logger.ErrorCtx(ctx, err), err.Error())
@@ -78,7 +83,7 @@ func (s *CalendarServer) UpdateEvent(ctx context.Context, req *pb.UpdateEventReq
 
 // DeleteEvent handles deletion of an event via gRPC.
 func (s *CalendarServer) DeleteEvent(ctx context.Context, req *pb.DeleteEventReq) (*emptypb.Empty, error) {
-	ctx = logger.WithLogMethod(ctx, "DeleteEvent")
+	ctx = s.setLogCompMeth(ctx, "DeleteEvent")
 	id, err := getEventIDFromBody(ctx, s.logger, req)
 	if err != nil {
 		s.logger.ErrorContext(logger.ErrorCtx(ctx, err), err.Error())
@@ -117,7 +122,7 @@ func (s *CalendarServer) getEvents(
 	req *pb.GetEventsReq,
 	getFunc func(context.Context, time.Time) ([]storage.Event, error),
 ) (*pb.GetEventsResp, error) {
-	ctx = logger.WithLogMethod(ctx, methodName)
+	ctx = s.setLogCompMeth(ctx, methodName)
 
 	start, err := getStartTime(ctx, s.logger, req)
 	if err != nil {

--- a/hw12_13_14_15_16_calendar/internal/server/grpc/utils.go
+++ b/hw12_13_14_15_16_calendar/internal/server/grpc/utils.go
@@ -30,6 +30,7 @@ func getEventFromBody[T interface{ GetEvent() *pb.Event }](
 	log *slog.Logger,
 	req T,
 ) (storage.Event, error) {
+	ctx = logger.WithLogComponent(ctx, "server.grpc")
 	ctx = logger.WithLogMethod(ctx, "getEventFromBody")
 	log.DebugContext(ctx, "attempting to extract event from request body")
 	eventPB := req.GetEvent()
@@ -62,6 +63,7 @@ func getEventIDFromBody[T interface{ GetId() string }](
 	log *slog.Logger,
 	req T,
 ) (uuid.UUID, error) {
+	ctx = logger.WithLogComponent(ctx, "server.grpc")
 	ctx = logger.WithLogMethod(ctx, "getEventIDFromBody")
 	log.DebugContext(ctx, "attempting to extract event ID from request parameters")
 	id := req.GetId()
@@ -82,6 +84,7 @@ func getStartTime[T interface{ GetStart() *timestamppb.Timestamp }](
 	log *slog.Logger,
 	req T,
 ) (time.Time, error) {
+	ctx = logger.WithLogComponent(ctx, "server.grpc")
 	ctx = logger.WithLogMethod(ctx, "getStartTime")
 	log.DebugContext(ctx, "attempting to extract start time from request parameters")
 	startTimestamp := req.GetStart()

--- a/hw12_13_14_15_16_calendar/internal/server/http/handler.go
+++ b/hw12_13_14_15_16_calendar/internal/server/http/handler.go
@@ -26,7 +26,7 @@ func (s *Server) routes() http.Handler {
 
 // CreateEvent handles event creation request.
 func (s *Server) CreateEvent(w http.ResponseWriter, r *http.Request) {
-	ctx := logger.WithLogMethod(r.Context(), "CreateEvent")
+	ctx := s.setLogCompMeth(r.Context(), "CreateEvent")
 
 	event, err := s.getEventFromBody(ctx, r)
 	if err != nil {
@@ -51,7 +51,7 @@ func (s *Server) CreateEvent(w http.ResponseWriter, r *http.Request) {
 
 // UpdateEvent handles event update request.
 func (s *Server) UpdateEvent(w http.ResponseWriter, r *http.Request) {
-	ctx := logger.WithLogMethod(r.Context(), "UpdateEvent")
+	ctx := s.setLogCompMeth(r.Context(), "UpdateEvent")
 
 	uuID, err := s.getEventIDFromBody(ctx, r)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *Server) UpdateEvent(w http.ResponseWriter, r *http.Request) {
 
 // DeleteEvent handles event deletion request.
 func (s *Server) DeleteEvent(w http.ResponseWriter, r *http.Request) {
-	ctx := logger.WithLogMethod(r.Context(), "DeleteEvent")
+	ctx := s.setLogCompMeth(r.Context(), "DeleteEvent")
 
 	uuID, err := s.getEventIDFromBody(ctx, r)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *Server) handleGetEvents(
 	period string,
 	getEventsFunc func(ctx context.Context, start time.Time) ([]storage.Event, error),
 ) {
-	ctx := logger.WithLogMethod(r.Context(), "GetEvents"+period)
+	ctx := s.setLogCompMeth(r.Context(), "GetEvents"+period)
 
 	startStr := r.URL.Query().Get("start")
 	start, err := time.Parse(time.RFC3339, startStr)

--- a/hw12_13_14_15_16_calendar/internal/server/http/server.go
+++ b/hw12_13_14_15_16_calendar/internal/server/http/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/EvGesh4And/golang-homework/hw12_13_14_15_16_calendar/internal/logger"
 	"github.com/EvGesh4And/golang-homework/hw12_13_14_15_16_calendar/internal/server"
 )
 
@@ -16,6 +17,11 @@ type Server struct {
 	app        server.Application
 	httpServer *http.Server
 	handler    http.Handler
+}
+
+func (s *Server) setLogCompMeth(ctx context.Context, method string) context.Context {
+	ctx = logger.WithLogComponent(ctx, "server.http")
+	return logger.WithLogMethod(ctx, method)
 }
 
 // Handler returns http.Handler used by the server.

--- a/hw12_13_14_15_16_calendar/internal/server/http/utils.go
+++ b/hw12_13_14_15_16_calendar/internal/server/http/utils.go
@@ -15,22 +15,22 @@ import (
 func (s *Server) getEventFromBody(ctx context.Context, r *http.Request) (storage.Event, error) {
 	var event storage.EventDTO
 	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
-		return storage.Event{}, err
+		return storage.Event{}, logger.WrapError(ctx, err)
 	}
 	s.logger.DebugContext(ctx, "request body successfully parsed into event")
 	return storage.FromDTO(event), nil
 }
 
 func (s *Server) getEventIDFromBody(ctx context.Context, r *http.Request) (uuid.UUID, error) {
-	ctx = logger.WithLogMethod(ctx, "getEventIDFromBody")
+	ctx = s.setLogCompMeth(ctx, "getEventIDFromBody")
 	s.logger.DebugContext(ctx, "attempting to extract event ID from request parameters")
 	id := r.URL.Query().Get("id")
 	if id == "" {
-		return uuid.Nil, server.ErrMissingEventID
+		return uuid.Nil, logger.WrapError(ctx, server.ErrMissingEventID)
 	}
 	uuID, err := uuid.Parse(id)
 	if err != nil {
-		return uuid.Nil, server.ErrInvalidEventID
+		return uuid.Nil, logger.WrapError(ctx, server.ErrInvalidEventID)
 	}
 	ctx = logger.WithLogEventID(ctx, uuID)
 	s.logger.DebugContext(ctx, "event ID successfully extracted from request parameters")

--- a/hw12_13_14_15_16_calendar/internal/storage/memory/storage.go
+++ b/hw12_13_14_15_16_calendar/internal/storage/memory/storage.go
@@ -31,8 +31,14 @@ func New(logger *slog.Logger) *Storage {
 }
 
 // CreateEvent adds a new event to storage.
+func (s *Storage) setLogCompMeth(ctx context.Context, method string) context.Context {
+	ctx = logger.WithLogComponent(ctx, "storage.memory")
+	return logger.WithLogMethod(ctx, method)
+}
+
+// CreateEvent adds a new event to storage.
 func (s *Storage) CreateEvent(ctx context.Context, event storage.Event) error {
-	ctx = logger.WithLogMethod(ctx, "CreateEvent")
+	ctx = s.setLogCompMeth(ctx, "CreateEvent")
 	s.logger.DebugContext(ctx, "attempting to create event")
 
 	if err := ctx.Err(); err != nil {
@@ -56,6 +62,7 @@ func (s *Storage) CreateEvent(ctx context.Context, event storage.Event) error {
 
 // UpdateEvent replaces an existing event.
 func (s *Storage) UpdateEvent(ctx context.Context, id uuid.UUID, newEvent storage.Event) error {
+	ctx = s.setLogCompMeth(ctx, "UpdateEvent")
 	s.logger.DebugContext(ctx, "attempting to update event")
 
 	if err := ctx.Err(); err != nil {
@@ -81,6 +88,7 @@ func (s *Storage) UpdateEvent(ctx context.Context, id uuid.UUID, newEvent storag
 
 // DeleteEvent removes an event from storage.
 func (s *Storage) DeleteEvent(ctx context.Context, id uuid.UUID) error {
+	ctx = s.setLogCompMeth(ctx, "DeleteEvent")
 	s.logger.DebugContext(ctx, "attempting to delete event")
 
 	if err := ctx.Err(); err != nil {
@@ -128,7 +136,7 @@ func (s *Storage) getEvents(ctx context.Context, start time.Time, period string)
 		d = time.Hour * 24 * 30
 	}
 
-	ctx = logger.WithLogMethod(ctx, fmt.Sprintf("GetEvents%s", period))
+	ctx = s.setLogCompMeth(ctx, fmt.Sprintf("GetEvents%s", period))
 	ctx = logger.WithLogStart(ctx, start)
 
 	s.logger.DebugContext(ctx, "attempting to get events for interval")


### PR DESCRIPTION
## Summary
- standardize logging across calendar components
- add log component info and wrap errors for context

## Testing
- `go test ./...` *(fails: module download requires internet)*

------
https://chatgpt.com/codex/tasks/task_e_686056a80c348329a7877f05956ac343